### PR TITLE
Add channel to params

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 ruby "2.5.1"
 
+gem "activesupport", require: "active_support/all"
 gem "puma"
 gem "puma-heroku"
 gem "rollbar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   codeclimate-test-reporter (~> 1.0.0)
   coveralls
   foreman
@@ -119,5 +120,8 @@ DEPENDENCIES
   sinatra-contrib
   slack-notifier
 
+RUBY VERSION
+   ruby 2.5.1p57
+
 BUNDLED WITH
-   1.16.1
+   1.16.5

--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ https://slack.com/apps/A0F7XDUAZ-incoming-webhooks
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 ### 3. Register webhook to Docker Hub
-Register webhook url (e.g. `https://MY-APP-NAME.herokuapp.com/webhook`)
+Register webhook url
+
+e.g. 
+
+* `https://MY-APP-NAME.herokuapp.com/webhook`
+  * Without `channel` query, notify to `SLACK_CHANNEL`
+* `https://MY-APP-NAME.herokuapp.com/webhook?channel=other_channel`
+  * With `channel` query, notify to specific channel. (`#` is needless)
 
 ![Docker Hub](img/dockerhub.png)
 

--- a/app.rb
+++ b/app.rb
@@ -24,7 +24,7 @@ class App < Sinatra::Base
   post "/webhook" do
     payload = JSON.parse(request.body.read)
 
-    logger.debug { "payload=#{payload}" }
+    logger.debug { "payload=#{payload}, params=#{params}" }
 
     message = <<~MSG
       Build finished by @#{payload["push_data"]["pusher"]} :beer:
@@ -34,9 +34,16 @@ class App < Sinatra::Base
 
     logger.debug { "message=#{message}" }
 
+    channel =
+      if params[:channel].blank?
+        ENV["SLACK_CHANNEL"]
+      else
+        "#" + params[:channel]
+      end
+
     App.post_slack(
       webhook_url: ENV["SLACK_WEBHOOK_URL"],
-      channel:     ENV["SLACK_CHANNEL"],
+      channel:     channel,
       username:    ENV["SLACK_USERNAME"],
       message:     message,
     )

--- a/app.rb
+++ b/app.rb
@@ -22,14 +22,14 @@ class App < Sinatra::Base
   end
 
   post "/webhook" do
-    params = JSON.parse(request.body.read)
+    payload = JSON.parse(request.body.read)
 
-    logger.debug { "params=#{params}" }
+    logger.debug { "payload=#{payload}" }
 
     message = <<~MSG
-      Build finished by @#{params["push_data"]["pusher"]} :beer:
-      #{params["repository"]["repo_name"]}:#{params["push_data"]["tag"]}
-      #{params["repository"]["repo_url"]}
+      Build finished by @#{payload["push_data"]["pusher"]} :beer:
+      #{payload["repository"]["repo_name"]}:#{payload["push_data"]["tag"]}
+      #{payload["repository"]["repo_url"]}
     MSG
 
     logger.debug { "message=#{message}" }

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -6,18 +6,16 @@ describe App do
   end
 
   describe "POST /webhook" do
-    subject { post "/webhook", payload, { "CONTENT_TYPE" => "application/json" } }
-
     before do
       ENV["SLACK_WEBHOOK_URL"] = webhooK_url
-      ENV["SLACK_CHANNEL"]     = channel
+      ENV["SLACK_CHANNEL"]     = env_channel
       ENV["SLACK_USERNAME"]    = username
 
       allow(App).to receive(:post_slack)
     end
 
     let(:webhooK_url) { "https://hooks.slack.com/services/XXXXXXXX/XXXXXXXX/XXXXXXXX" }
-    let(:channel)     { "#general" }
+    let(:env_channel) { "#general" }
     let(:username)    { "Docker Hub Build" }
     let(:message) do
       <<~MSG
@@ -61,13 +59,17 @@ describe App do
       JSON
     end
 
-    it { should be_ok }
+    context "without channel in params" do
+      subject { post "/webhook", payload, { "CONTENT_TYPE" => "application/json" } }
 
-    it "called post_slack" do
-      subject
+      it { should be_ok }
 
-      expect(App).to have_received(:post_slack).
-                       with(webhook_url: webhooK_url, channel: channel, username: username, message: message)
+      it "called post_slack" do
+        subject
+
+        expect(App).to have_received(:post_slack).
+          with(webhook_url: webhooK_url, channel: env_channel, username: username, message: message)
+      end
     end
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -71,5 +71,31 @@ describe App do
           with(webhook_url: webhooK_url, channel: env_channel, username: username, message: message)
       end
     end
+
+    context "with empty channel in params" do
+      subject { post "/webhook?channel=", payload, { "CONTENT_TYPE" => "application/json" } }
+
+      it { should be_ok }
+
+      it "called post_slack" do
+        subject
+
+        expect(App).to have_received(:post_slack).
+          with(webhook_url: webhooK_url, channel: env_channel, username: username, message: message)
+      end
+    end
+
+    context "with channel in params" do
+      subject { post "/webhook?channel=random", payload, { "CONTENT_TYPE" => "application/json" } }
+
+      it { should be_ok }
+
+      it "called post_slack" do
+        subject
+
+        expect(App).to have_received(:post_slack).
+          with(webhook_url: webhooK_url, channel: "#random", username: username, message: message)
+      end
+    end
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -68,7 +68,7 @@ describe App do
         subject
 
         expect(App).to have_received(:post_slack).
-          with(webhook_url: webhooK_url, channel: env_channel, username: username, message: message)
+                         with(webhook_url: webhooK_url, channel: env_channel, username: username, message: message)
       end
     end
 
@@ -81,7 +81,7 @@ describe App do
         subject
 
         expect(App).to have_received(:post_slack).
-          with(webhook_url: webhooK_url, channel: env_channel, username: username, message: message)
+                         with(webhook_url: webhooK_url, channel: env_channel, username: username, message: message)
       end
     end
 
@@ -94,7 +94,7 @@ describe App do
         subject
 
         expect(App).to have_received(:post_slack).
-          with(webhook_url: webhooK_url, channel: "#random", username: username, message: message)
+                         with(webhook_url: webhooK_url, channel: "#random", username: username, message: message)
       end
     end
   end


### PR DESCRIPTION
* `https://MY-APP-NAME.herokuapp.com/webhook`
  * Without `channel` query, notify to `SLACK_CHANNEL`
* `https://MY-APP-NAME.herokuapp.com/webhook?channel=other_channel`
  * With `channel` query, notify to specific channel. (`#` is needless)
