### PR TITLE
[CVE-2023-36617] Upgrade to uri 0.12.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "puma"
 gem "sentry-ruby"
 gem "sinatra-contrib", ">= 2.2.0"
 gem "slack-notifier", ">= 2.4.0"
+gem "uri", ">= 0.12.2" # for CVE-2023-36617
 
 group :development do
   gem "onkcop", ">= 1.0.0.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    uri (0.12.2)
 
 PLATFORMS
   ruby
@@ -126,6 +127,7 @@ DEPENDENCIES
   simplecov
   sinatra-contrib (>= 2.2.0)
   slack-notifier (>= 2.4.0)
+  uri (>= 0.12.2)
 
 BUNDLED WITH
    2.3.7


### PR DESCRIPTION
ref. https://www.ruby-lang.org/en/news/2023/06/29/redos-in-uri-CVE-2023-36617/